### PR TITLE
Detect and ignore empty "if" or "else" code blocks. Fix "c_nop" code block …

### DIFF
--- a/compiler/constructs/c_if.php
+++ b/compiler/constructs/c_if.php
@@ -4,6 +4,14 @@ namespace js4php5\compiler\constructs;
 
 class c_if extends BaseConstruct
 {
+
+    /**
+     * Constructor.
+     *
+     * @param \js4php5\compiler\constructs\c_literal_boolean|mixed $cond Condition.
+     * @param \js4php5\compiler\constructs\c_block|mixed $ifblock If block.
+     * @param \js4php5\compiler\constructs\c_block|\js4php5\compiler\constructs\c_nop|mixed $elseblock Else block.
+     */
     function __construct($cond, $ifblock, $elseblock = null)
     {
         $this->cond = $cond;
@@ -14,7 +22,9 @@ class c_if extends BaseConstruct
     function emit($unusedParameter = false)
     {
         $o = "if (Runtime::js_bool(" . $this->cond->emit(true) . ")) " . $this->ifblock->emit(true);
-        if ($this->elseblock) {
+        // If we have a "else" block and it's not empty.
+        if ($this->elseblock && !$this->elseblock instanceof c_nop) {
+            // Parse "else" block.
             $o = rtrim($o) . " else " . $this->elseblock->emit(true) . "\n";
         }
         return $o;

--- a/compiler/constructs/c_nop.php
+++ b/compiler/constructs/c_nop.php
@@ -6,7 +6,8 @@ class c_nop extends BaseConstruct
 {
     function emit($unusedParameter = false)
     {
-        return '';
+        // Emit an empty code block.
+        return '{}';
     }
 }
 


### PR DESCRIPTION
Detect and ignore empty "if" or "else" code blocks. Fix "c_nop" code block to emit '{}' instead ''.